### PR TITLE
Add bare-bones versions of FemtoLisp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ These single-file implementations are rarely complete, hardly sophisticated or e
 
 [single_cream](https://github.com/rain-1/single_cream), scheme interpreter implemented by Raymond Nicholson.
 
+[lisp-nontail.c](https://github.com/JeffBezanson/femtolisp/blob/master/tiny/lisp-nontail.c) implemented by Jeff Bezanson. Lexical scope and GC in <1000 lines.
+
+[lisp.c](https://github.com/JeffBezanson/femtolisp/blob/master/tiny/lisp.c) implemented by Jeff Bezanson. Lexical scope, tail calls and GC in ~1000 lines.
+
 [ulc](https://github.com/masaeedu/ulc) implemented by Asad Saeeduddin. A minimalistic implementation of the untyped lambda calculus in JS
 
 ## Imperative

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These single-file implementations are rarely complete, hardly sophisticated or e
 
 [komplott](https://github.com/krig/LISP) implemented by Kristoffer Grönlund.
 
-[Lisp500](https://web.archive.org/web/20040305005602/http://modeemi.cs.tut.fi/~chery/lisp500/) implemented by Teemu Kalvas. 
+[Lisp500](https://web.archive.org/web/20040305005602/http://modeemi.cs.tut.fi/~chery/lisp500/) implemented by Teemu Kalvas.
 
 [Lisp9](https://www.t3x.org/lisp9/index.html) implemented by Nils M. Holm. A byte-compiling Lisp interpreter.
 
@@ -66,7 +66,7 @@ These single-file implementations are rarely complete, hardly sophisticated or e
 [jonesForth](https://github.com/nornagon/jonesforth/blob/master/jonesforth.S) implemented by Richard W.M. Jones.
 
 mescc-tools-seed, implemented by Jeremiah Orians. A complete chain of
-one-file languages, from compiler to assemblers and even a shell, for Intel x86: 
+one-file languages, from compiler to assemblers and even a shell, for Intel x86:
 [C compiler in assembly](https://github.com/oriansj/mescc-tools-seed/blob/master/x86/cc_x86.M1),
 [macro assembler to build the C compiler](https://github.com/oriansj/mescc-tools-seed/blob/master/x86/M0_x86.hex2),
 [hex2 assembler to build the macro assembler](https://github.com/oriansj/mescc-tools-seed/blob/master/x86/hex2_x86.hex1),
@@ -110,7 +110,7 @@ one-file languages, from compiler to assemblers and even a shell, for Intel x86:
 
 [A Regular Expression Matcher](http://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html) implemented by Rob Pike, exegesis by Brian Kernighan.
 
-[JS-Interpreter](https://github.com/NeilFraser/JS-Interpreter/blob/master/interpreter.js) implemented by Neil Fraser. A JavaScript interpreter in JavaScript. This file is part of a larger project for running JavaScript in a sandbox. 
+[JS-Interpreter](https://github.com/NeilFraser/JS-Interpreter/blob/master/interpreter.js) implemented by Neil Fraser. A JavaScript interpreter in JavaScript. This file is part of a larger project for running JavaScript in a sandbox.
 
 [Microlisp](https://github.com/lazear/microlisp), a Scheme-like lisp in less than 1000 loc of C, implemented by Michael Lazear. A single-implementation with extra files for examples and building.
 


### PR DESCRIPTION
These are impressively small Scheme interpreters by Jeff Bezanson, now of Julia fame. They are experimental/pedagogical versions of the FemtoLisp evaluator with inessential features removed. FL is also great but requires several thousand lines of C, many files and a boot image.

These interpreters load a `system.lsp` file containing the standard library, but you can replace it with an empty file and they still work. In that case you have to write your code like this:

```scheme
> (set 'factorial (lambda (n) (if (< n 1) 1 (* n (factorial (- n 1))))))
(lambda (n) (if (< n 1) 1 (* n (factorial (- n 1)))))

> (factorial 10)
3628800
```